### PR TITLE
Move templates from error policy into its methods

### DIFF
--- a/test/refined_test.cpp
+++ b/test/refined_test.cpp
@@ -14,7 +14,7 @@ TEST_CASE(
   STATIC_REQUIRE(std::is_same_v<decltype(even::make(0)), std::optional<even>>);
 
   STATIC_REQUIRE(
-      std::is_same_v<decltype(even::make<refined::error::to_optional<even>>(0)),
+      std::is_same_v<decltype(even::make<refined::error::to_optional>(0)),
                      std::optional<even>>);
 
   STATIC_REQUIRE(even::make(0)->value == 0);
@@ -27,10 +27,10 @@ TEST_CASE("A to_exception policy should throw on invalid argument",
           "[error_policy][to_exception]") {
 
   STATIC_REQUIRE(
-      std::is_same_v<
-          decltype(even::make<refined::error::to_exception<even>>(10)), even>);
+      std::is_same_v<decltype(even::make<refined::error::to_exception>(10)),
+                     even>);
 
-  STATIC_REQUIRE(even::make<refined::error::to_exception<even>>(0).value == 0);
-  REQUIRE_THROWS_AS(even::make<refined::error::to_exception<even>>(1),
-                    refined::error::to_exception<even>::refinement_exception);
+  STATIC_REQUIRE(even::make<refined::error::to_exception>(0).value == 0);
+  REQUIRE_THROWS_AS(even::make<refined::error::to_exception>(1),
+                    refined::error::to_exception::refinement_exception);
 }


### PR DESCRIPTION
This avoids repeating the refinement type when parameterising a refinement factory with a custom policy.

E.g. from: `error::to_optional<even>` to: `error::to_optional` (no more `<even>` is required)