### PR TITLE
Add traits for richer-types

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,8 @@ With this example, we notice that not all functions need access to the underlyin
 
 Although we reported errors via `std::optional` in the example, we can customise it, e.g. to throw an exception with the built-in `even::make<refined::error::to_exception>` or define a whole user-provided policy.
 
+Furthermore, with `rvarago::refined::traits` we can extend a refinement with properties, such as ordered with the spaceship operator.
+
 ## Requirements
 
 C++20
@@ -62,9 +64,6 @@ C++20
 ## Usage
 
 This is a header-only library. See [`refined.hpp`](include/rvarago/refined.hpp).
-
-- (Optional) Link against the INTERFACE `rvarago::refined` target in your CMake build.
-- Include `rvarago/refined.hpp`
 
 ## Contributing
 

--- a/include/rvarago/refined.hpp
+++ b/include/rvarago/refined.hpp
@@ -8,7 +8,10 @@ namespace rvarago::refined {
 
 // Properties a refinement implements.
 struct traits {
-  // Comparison operations with the spaceship operator.
+  // Equality comparison (`==`, `!=`).
+  bool equality{false};
+
+  // Comparison operations (`<`, `>`, etc) with the spaceship operator.
   bool ordered{false};
 };
 
@@ -63,6 +66,11 @@ public:
   static constexpr auto unverified_make(T value) -> refinement {
     return refinement{std::move(value)};
   }
+
+  friend constexpr auto operator==(refinement const &, refinement const &)
+      -> bool
+    requires(Traits.equality)
+  = default;
 
   friend constexpr auto operator<=>(refinement const &, refinement const &)
     requires(Traits.ordered)

--- a/include/rvarago/refined.hpp
+++ b/include/rvarago/refined.hpp
@@ -6,7 +6,14 @@
 
 namespace rvarago::refined {
 
-template <typename T, std::predicate<T const &> auto Pred, typename... Bases>
+// Properties a refinement implements.
+struct traits {
+  // Comparison operations with the spaceship operator.
+  bool ordered{false};
+};
+
+template <typename T, std::predicate<T const &> auto Pred, traits Traits = {},
+          typename... Bases>
   requires((std::is_same_v<T, typename Bases::value_type> && ...) &&
            (std::predicate<typename Bases::predicate_type, T const &> && ...))
 class refinement {
@@ -56,6 +63,10 @@ public:
   static constexpr auto unverified_make(T value) -> refinement {
     return refinement{std::move(value)};
   }
+
+  friend constexpr auto operator<=>(refinement const &, refinement const &)
+    requires(Traits.ordered)
+  = default;
 
 private:
   explicit constexpr refinement(T value) : value_{std::move(value)} {}

--- a/test/refined_test.cpp
+++ b/test/refined_test.cpp
@@ -34,11 +34,13 @@ TEST_CASE("Two refinement types with same ground types and nominally defined "
           "subtyping are implicily convertible",
           "[predicate_subtyping]") {
   using even_lt_10 =
-      refined::refinement<int, [](auto const x) { return x < 10; }, even>;
+      refined::refinement<int, [](auto const x) { return x < 10; },
+                          refined::traits{.ordered = true}, even>;
 
   STATIC_REQUIRE(std::is_constructible_v<even, even_lt_10>);
 
   constexpr even valid = *even_lt_10::make(8);
+
   STATIC_REQUIRE(valid.value() == 8);
 
   constexpr std::optional<even> invalid = even_lt_10::make(10);
@@ -55,4 +57,13 @@ TEST_CASE("A to_exception policy should throw on invalid argument",
   STATIC_REQUIRE(even::make<refined::error::to_exception>(0).value() == 0);
   REQUIRE_THROWS_AS(even::make<refined::error::to_exception>(1),
                     refined::error::to_exception::refinement_exception);
+}
+
+TEST_CASE("A refinement can be ordered", "[traits][sorted]") {
+
+  using ref_cmp = refined::refinement<int, [](auto const &) { return true; },
+                                      refined::traits{.ordered = true}>;
+
+  STATIC_REQUIRE(*ref_cmp::make(1) < *ref_cmp::make(2));
+  STATIC_REQUIRE(!(*ref_cmp::make(2) < *ref_cmp::make(1)));
 }

--- a/test/refined_test.cpp
+++ b/test/refined_test.cpp
@@ -59,6 +59,15 @@ TEST_CASE("A to_exception policy should throw on invalid argument",
                     refined::error::to_exception::refinement_exception);
 }
 
+TEST_CASE("A refinement can be equality comparable", "[traits][equality]") {
+
+  using ref_cmp = refined::refinement<int, [](auto const &) { return true; },
+                                      refined::traits{.equality = true}>;
+
+  STATIC_REQUIRE(*ref_cmp::make(1) == *ref_cmp::make(1));
+  STATIC_REQUIRE(*ref_cmp::make(1) != *ref_cmp::make(2));
+}
+
 TEST_CASE("A refinement can be ordered", "[traits][sorted]") {
 
   using ref_cmp = refined::refinement<int, [](auto const &) { return true; },


### PR DESCRIPTION
Users can now ask for a refinement that can be equality comparable (`==`, `!=`) and ordered (`<`, `>`, etc).